### PR TITLE
Fix attrs version for backward compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         'six',
         'python-decouple',
-        'attrs',
+        'attrs>=16.3.0,<17.3.0',
         'xmltodict',
         'requests',
         'future',


### PR DESCRIPTION
The version 17.0.3 of attrs produces crashes. Fix version to 17.0.2